### PR TITLE
Avoid 301 API redirects: don't escape path slashes.

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -117,7 +117,7 @@ module.exports = function(config){
       var scopepath = fileop ? "" : scope
 
       // we wont always have this
-      var filepath = obj.path ? qs.escape(obj.path) : ""
+      var filepath = obj.path ? qs.escape(obj.path).replace(/%2F/g,'/') : ""
       
       // build full path
       var fullpath = path.join(obj.hostname)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dbox",
   "description": "NodeJS SDK for the Dropbox API",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "author": "Brock Whitten <brock@sintaxi.com>",
   "contributors": [
     { "name": "Brock Whitten", "email": "brock@sintaxi.com" },


### PR DESCRIPTION
Dropbox has suddenly started 301 redirecting

```
/1/media/sandbox%2Ftest-project-6%2Fpreview.wav
```

to

```
/1/media/sandbox/test-project-6/preview.wav
```

This breaks API endpoints that POST, like `dbox.media`, because the `request` module doesn't follow non-GET redirects by default. (And following them anyway is problematic.)

This is a hack to url-decode just path slashes in api calls. Hopefully this doesn't break other API endpoints. (Note: url-decoding via regex is not technically correct, we need better parsing.)
